### PR TITLE
make source hover rather than click

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -475,11 +475,10 @@ export default class App extends React.Component {
           </div>
           }
           { this.state.statusMessageCitation !== "" ? 
-          <div style={{position: "absolute", right : "5px", bottom: "0px", color : "#CCCC66" }} 
-            onMouseDown={() => this.toggleCitationOn()}
-            onMouseUp={() => this.toggleCitationOff()}
-            onMouseLeave={() => this.toggleCitationOff()}
-            >Source</div>
+          <div style={{position: "absolute", right : "5px", bottom: "0px", color : "#3f65c1" }} 
+            onMouseOver={() => this.toggleCitationOn()}
+            onMouseOut={() => this.toggleCitationOff()}
+            >source</div>
           : null
           }
         </div>


### PR DESCRIPTION
I love the way you added the source functionality here!! This is just a suggestion – but I think it might work better if source appears when someone hovers their cursor over the "source" label ... rather than clicks it. (I think on a touch screen it will work that if you touch "source" it will trigger, and when you touch anywhere else it will revert... but we would need to test to make sure.) 

Also, from a design standpoint, I think lowercase "source" looks better.