### PR TITLE
fix capitalization of .ScorePD class

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -130,11 +130,10 @@ body {
     text-align:right
 }
 
-.scorePD {
+.ScorePD {
     text-align:left;
     position: relative;
     top: -.1em;
-    left: -.3em;
 }
 
 .BudgetBar {


### PR DESCRIPTION
I couldn't figure why formatting changes to the PD score weren't working ..... but I guess css class names are case sensitive. Who knew?!